### PR TITLE
Add initial view controller

### DIFF
--- a/Sources/Controllers/AppDelegate.swift
+++ b/Sources/Controllers/AppDelegate.swift
@@ -21,7 +21,7 @@ extension AppDelegate: UIApplicationDelegate {
 private extension AppDelegate {
   func createWindow() -> UIWindow {
     let window = UIWindow(frame: UIScreen.main.bounds)
-    window.backgroundColor = UIColor.blue
+    window.backgroundColor = UIColor.white
     window.rootViewController = ApplicationViewController(controller: applicationController)
     return window
   }

--- a/Sources/Controllers/ApplicationController.swift
+++ b/Sources/Controllers/ApplicationController.swift
@@ -1,1 +1,5 @@
-struct ApplicationController {}
+struct ApplicationController {
+  var viewModel: ApplicationViewModel {
+    return ApplicationViewModel()
+  }
+}

--- a/Sources/Controllers/ApplicationViewController.swift
+++ b/Sources/Controllers/ApplicationViewController.swift
@@ -2,6 +2,11 @@ import UIKit
 
 final class ApplicationViewController: UIViewController {
   let controller: ApplicationController
+  var activeViewController: UIViewController?
+
+  var viewModel: ApplicationViewModel {
+    return controller.viewModel
+  }
 
   init(controller: ApplicationController) {
     self.controller = controller
@@ -10,5 +15,32 @@ final class ApplicationViewController: UIViewController {
 
   required init(coder: NSCoder) {
     fatalError()
+  }
+}
+
+// MARK: View Lifecycle
+extension ApplicationViewController {
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    let initialViewController = WorkoutsViewController(viewModel: viewModel.workoutsViewModel)
+
+    changeActive(viewController: initialViewController)
+  }
+}
+
+private extension ApplicationViewController {
+  func changeActive(viewController: UIViewController) {
+    if let activeViewController = activeViewController {
+      activeViewController.willMove(toParentViewController: .none)
+      activeViewController.view.removeFromSuperview()
+      activeViewController.removeFromParentViewController()
+    }
+
+    viewController.willMove(toParentViewController: self)
+    addChildViewController(viewController)
+    view.addSubview(viewController.view)
+    viewController.didMove(toParentViewController: self)
+
+    activeViewController = viewController
   }
 }

--- a/Sources/Controllers/WorkoutsViewController.swift
+++ b/Sources/Controllers/WorkoutsViewController.swift
@@ -1,0 +1,14 @@
+import UIKit
+
+final class WorkoutsViewController: UITableViewController {
+  let viewModel: CollectionViewModel<Workout>
+
+  init(viewModel: CollectionViewModel<Workout>) {
+    self.viewModel = viewModel
+    super.init(nibName: .none, bundle: .none)
+  }
+
+  required init(coder: NSCoder) {
+    fatalError()
+  }
+}

--- a/Sources/Models/Workout.swift
+++ b/Sources/Models/Workout.swift
@@ -1,0 +1,1 @@
+struct Workout {}

--- a/Sources/ViewModels/ApplicationViewModel.swift
+++ b/Sources/ViewModels/ApplicationViewModel.swift
@@ -1,0 +1,5 @@
+struct ApplicationViewModel {
+  var workoutsViewModel: CollectionViewModel<Workout> {
+    return .init(models: [])
+  }
+}

--- a/Sources/ViewModels/CollectionViewModel.swift
+++ b/Sources/ViewModels/CollectionViewModel.swift
@@ -1,0 +1,7 @@
+struct CollectionViewModel<T> {
+  private let models: [T]
+
+  init(models: [T]) {
+    self.models = models
+  }
+}

--- a/Swole.xcodeproj/project.pbxproj
+++ b/Swole.xcodeproj/project.pbxproj
@@ -10,6 +10,10 @@
 		0916091038786480DDB60623 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E70145FBD5C648E66EF5C8E /* AppDelegate.swift */; };
 		1DE43A2D2C2FAE49680791FA /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = AC836B86FBDC9EA4DC586C10 /* LaunchScreen.xib */; };
 		29053ACA880A6924444AE06E /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1EF80D03D51BC6617CC193BA /* Images.xcassets */; };
+		F81A1ED41D6E04D30012DBCF /* Workout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81A1ED31D6E04D30012DBCF /* Workout.swift */; };
+		F81A1ED71D6E04DA0012DBCF /* ApplicationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81A1ED51D6E04DA0012DBCF /* ApplicationViewModel.swift */; };
+		F81A1ED81D6E04DA0012DBCF /* CollectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81A1ED61D6E04DA0012DBCF /* CollectionViewModel.swift */; };
+		F81A1EDA1D6E04DF0012DBCF /* WorkoutsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81A1ED91D6E04DF0012DBCF /* WorkoutsViewController.swift */; };
 		F8428BC31D6D5095004C449F /* Nimble.framework in Copy test dependencies */ = {isa = PBXBuildFile; fileRef = F8BB6D3B1D6D4A27005DD41D /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8428BC41D6D5095004C449F /* Quick.framework in Copy test dependencies */ = {isa = PBXBuildFile; fileRef = F8BB6D3C1D6D4A27005DD41D /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F89C8AE41D6DE7AF00D01961 /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F89C8AE31D6DE7AF00D01961 /* Dictionary.swift */; };
@@ -53,6 +57,10 @@
 		99AB8804CB615E2C3D97C94F /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AC836B86FBDC9EA4DC586C10 /* LaunchScreen.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = LaunchScreen.xib; sourceTree = "<group>"; };
 		B602DFC4A76E5FC883F2E19B /* Swole.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Swole.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F81A1ED31D6E04D30012DBCF /* Workout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Workout.swift; sourceTree = "<group>"; };
+		F81A1ED51D6E04DA0012DBCF /* ApplicationViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationViewModel.swift; sourceTree = "<group>"; };
+		F81A1ED61D6E04DA0012DBCF /* CollectionViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewModel.swift; sourceTree = "<group>"; };
+		F81A1ED91D6E04DF0012DBCF /* WorkoutsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WorkoutsViewController.swift; sourceTree = "<group>"; };
 		F89C8AE31D6DE7AF00D01961 /* Dictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dictionary.swift; sourceTree = "<group>"; };
 		F89C8AE51D6DEB1600D01961 /* ApplicationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationController.swift; sourceTree = "<group>"; };
 		F89C8AE61D6DEB1600D01961 /* ApplicationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationViewController.swift; sourceTree = "<group>"; };
@@ -91,6 +99,7 @@
 		1C1DB052301C72C33C4CCDC9 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				F81A1ED31D6E04D30012DBCF /* Workout.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -105,6 +114,7 @@
 		3E512ED1AC04A2A40F8FEA51 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				F81A1ED91D6E04DF0012DBCF /* WorkoutsViewController.swift */,
 				F89C8AE51D6DEB1600D01961 /* ApplicationController.swift */,
 				F89C8AE61D6DEB1600D01961 /* ApplicationViewController.swift */,
 				0E70145FBD5C648E66EF5C8E /* AppDelegate.swift */,
@@ -184,6 +194,8 @@
 		D30601603E3BF73B1426840B /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				F81A1ED51D6E04DA0012DBCF /* ApplicationViewModel.swift */,
+				F81A1ED61D6E04DA0012DBCF /* CollectionViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -388,8 +400,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				F89C8AE81D6DEB1600D01961 /* ApplicationViewController.swift in Sources */,
+				F81A1ED71D6E04DA0012DBCF /* ApplicationViewModel.swift in Sources */,
+				F81A1ED81D6E04DA0012DBCF /* CollectionViewModel.swift in Sources */,
 				0916091038786480DDB60623 /* AppDelegate.swift in Sources */,
+				F81A1EDA1D6E04DF0012DBCF /* WorkoutsViewController.swift in Sources */,
 				F89C8AE71D6DEB1600D01961 /* ApplicationController.swift in Sources */,
+				F81A1ED41D6E04D30012DBCF /* Workout.swift in Sources */,
 				F89C8AE41D6DE7AF00D01961 /* Dictionary.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
The workouts view controller will eventually list the existing workouts, and
will allow you to create new workouts. For right now, we're showing an empty
list so that we can move forward.

This introduces a few new concepts:
- CollectionViewModel is a generic view model that I've had ideas about for a
  while now. These view models tend to be incredibly decoupled from the data
  they contain since they are essentially data sources for table/collection
  views. This version is currently generic over Workout instances, although I
  think that might change so that it's holding onto WorkoutViewModels at some
  point instead.
- We're using the ApplicationViewController as a container VC right now. This
  is clearly overkill as we have no auth or anything, but I think it'll be
  useful in the long run and it'll be nice to have it in place when we get
  there.
- The initial view model is vended by the ApplicationController, which has no
  actual other use. Again, this is overkill for now, but as we get more high
  level behavior I think it'll be useful to have this around to plug into.
